### PR TITLE
Shadow fixes + Aero Window Snap added

### DIFF
--- a/MetroFramework/Native/WinApi.cs
+++ b/MetroFramework/Native/WinApi.cs
@@ -79,10 +79,23 @@ namespace MetroFramework.Native
         [StructLayout(LayoutKind.Sequential)]
         public struct RECT
         {
+            public RECT(Rectangle rc)
+            {
+                this.Left = rc.Left;
+                this.Top = rc.Top;
+                this.Right = rc.Right;
+                this.Bottom = rc.Bottom;
+            }
+
             public int Left;
             public int Top;
             public int Right;
             public int Bottom;
+
+            public Rectangle ToRectangle()
+            {
+                return Rectangle.FromLTRB(Left, Top, Right, Bottom);
+            }
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -485,6 +498,9 @@ namespace MetroFramework.Native
 
         [DllImport("user32.dll")]
         public static extern int SetWindowLong(IntPtr hWnd, int nIndex, UInt32 dwNewLong);
+
+        [DllImport("user32.dll")]
+        public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int W, int H, uint uFlags);
 
         [DllImport("user32.dll")]
         public static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);


### PR DESCRIPTION
Fixes:
- Solution now runs demo, was broken due to some null objects

Added:
Aero Window Snap
- This is a controlled by a new property of
AeroWindowSnapActive,(default to true)
- Downside: there is a notable flicker on the edges if you are using the
Dark theme. This is due to windows drawing it's own border on deactivate
and activate events, so a hack for now is to redraw the window on those
events. Couldn't figure out a way to stop windows from drawing it's own
borders.